### PR TITLE
Carolyn branch

### DIFF
--- a/docs/_posts/2024-02-19-Visual_Arts_Competition.MD
+++ b/docs/_posts/2024-02-19-Visual_Arts_Competition.MD
@@ -12,27 +12,21 @@ tags:
   - Civics Education
 
 ---
-<span style="color:red; font-size:1em;"> **This competition will be launched on President’s Day, 2024. ** </span>
+<span style="color:red; font-size:1em;"> **This competition is currently in progress.  All entries are due by March 31, 2024.** </span>
 
-This page is still under construction.  Please check back on or after Feb 19, 2024.  You can scroll down to the bottom of this page for links to our past competitions.
-
-<!-- ![image-center]({{ site.url }}{{ site.baseurl }}/assets/images/2024-02-19-VAC_banner.jpg) -->
+![image-center]({{ site.url }}{{ site.baseurl }}/assets/images/2024-02-19-VAC_banner.jpg)
 
 Visual Arts Comeptition Committee:  Carolyn Joswig-Jones (Chair), Lennis Boyer, Deb Olson, Kat Odell, Aly Welch, Sutton Mooney, Beeler Lile, Karyn Hardy, Kimberly Tompson, Stephanie MacCulloch, Crowe Gammons, Carol Ndambuki
 
-<span style="color:green; font-size:2em;"> **Theme Coming Soon** </span>
+<span style="color:green; font-size:2em;"> **Why Does Voting Matter?** </span>
 
-## Theme?
-<!---Why Does Voting Matter?  -->
-General theme idea will go here.
-<!---Voting is the most basic act of citizenship. 
-YOU are a future Voter!  What MATTERS to you?  Who has the right to VOTE?
-The right to vote didn’t come easy for everyone.  Join us in exploring the history of voting rights, how the voting process works, and how every vote matters. -->
+## Why Does Voting Matter?
 
+Voting is the most basic act of citizenship. YOU are a future Voter!  What MATTERS to you?  Who has the right to VOTE? The right to vote didn’t come easy for everyone.  Join us in exploring the history of voting rights, how the voting process works, and how every vote matters.
 
 **Purpose:**
 
-This Art Competition is for students in grades 3-12 to share their artistic talent in portraying why voting matters.  This contest is designed to encourage understanding of and participation in government.  <!---LWV is a nonpartisan organization, and, as part of our civics education program this year, we want to celebrate our right to vote. -->
+This Art Competition is for students in grades 3-12 to share their artistic talent in portraying why voting matters.  This contest is designed to encourage understanding of and participation in government.  LWV is a nonpartisan organization, and, as part of our civics education program this year, we want to celebrate our right to vote.
 
 
 **Eligibility:**
@@ -57,13 +51,11 @@ $50 to spend at your local businesses and a copy of the LWVWA civics textbook, T
 
 **Art Competition Flyers and Entry Form:**
 
-<!---* [Click here to print the Entry Form](https://lwvpullman.org/assets/PDFs/2024-02-19-Entry_Form_Final.pdf)
+* [Click here to print the Entry Form](https://lwvpullman.org/assets/PDFs/2024-02-19-Entry_Form_Final.pdf)
 * [Click here for the On-Line Entry Form](https://docs.google.com/forms/d/e/1FAIpQLScDCffZ5DYZTP7pqc-Xk7Ln3jWQpMiQPSEYFYH2hZ-JGxqdXw/viewform)
 * [Click here for the Art Competition Flyer](https://lwvpullman.org/assets/PDFs/2024-Art_Comp_Flyer.pdf)
 * [Click here for promotional poster](https://lwvpullman.org/assets/PDFs/2024-02-19-Poster_pull_tabs_QR.pdf)
 * [Click here for promotional quarter sheet flyers](https://lwvpullman.org/assets/PDFs/2024-02-19-quarter_page_flyers.pdf)
--->
-
 **To submit your artwork and completed form:** 
 
 Drop-off:
@@ -87,15 +79,15 @@ Winners will be notified on April 12th via email.  An artists’ reception will 
 
 We have a small group of league volunteers who are prepared to give in-person presentations relating to our theme.  This program is up to one hour long and is for students in classrooms and organizations in Whitman County.  Below is a link to a PowerPoint and supplemental material for the program.  Please contact Deb Olson (olsonbones@aol.com) to schedule a presentation. 
 
-[Click here for the PowerPoint Presentation]( )
+[Click here for the PowerPoint Presentation]( )  Coming soon!
 
-[Click here for the Supplemental Material](https://lwvpullman.org/assets/PDFs/ .pdf)
+[Click here for the Supplemental Material](https://lwvpullman.org/assets/PDFs/2024-02-19-Supplement.pdf)
 
 ## Judges
 
 The judges are appointed by the LWV of Pullman (Whitman County).  They have qualifications in three areas; having knowledge in Government, Art and Environment.  The judges evaluate the submitted artwork based on creative interpretation of the theme.  We will be using [RANKED CHOICE VOTING](https://www.rankedvote.co/) to determine the winners.
 
-[Click here for the Panel of Judges for 2024](https://lwvpullman.org/assets/PDFs/ )
+[Click here for the Panel of Judges for 2024](https://lwvpullman.org/assets/PDFs/ )  Coming soon!
 
 ## Past Competitions
 

--- a/index.html
+++ b/index.html
@@ -42,12 +42,12 @@ feature_row:
     url: /about/
     btn_label: "Who Are We?"
     btn_class: "btn--primary"
-  - image_path: /assets/images/2024-01-Art_Comp_Coming_Soon.jpg
-    alt: "pic of an artist’s easel with a title of third annual visual arts, competition and launching on Presidents Day February 19, 2024"
+  - image_path: /assets/images/2024-02-19-VACC_Launch.jpg
+    alt: "Collage picture of a Happy Presidents Day button and red, white and blue stars background with theme for art competition on easel saying Why Does Voting Matter and other title saying it is the 3rd annual competition for students grades 3 to 12 living in Whitman County WA."
     title: "League Art Competition"
-    excerpt: "Our league will launch the third annual visual arts competition theme on Presidents Day February 19, 2024.  This art competition is for students in grades 3-12 living in Whitman County."
+    excerpt: "Calling all students in grades 3-12 living in Whitman County. Can you create artwork that embodies the theme of why voting matters to you?"
     url: 'https://lwvpullman.org/docs/art%20competition/civics%20education/Art_Competition/'
-    btn_label: "Check out the 2023 Competition!"
+    btn_label: "Check out the 2024 Competition!"
     btn_class: "btn--primary"
   - image_path: /assets/images/flag.png
     alt: "American Flag"

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ feature_row:
     alt: "Collage picture of a Happy Presidents Day button and red, white and blue stars background with theme for art competition on easel saying Why Does Voting Matter and other title saying it is the 3rd annual competition for students grades 3 to 12 living in Whitman County WA."
     title: "League Art Competition"
     excerpt: "Calling all students in grades 3-12 living in Whitman County. Can you create artwork that embodies the theme of why voting matters to you?"
-    url: 'https://lwvpullman.org/docs/art%20competition/civics%20education/Art_Competition/'
+    url: 'https://lwvpullman.org/docs/art%20competition/civics%20education/Visual_Arts_Competition/'
     btn_label: "Check out the 2024 Competition!"
     btn_class: "btn--primary"
   - image_path: /assets/images/flag.png


### PR DESCRIPTION
Please do not accept this pull request for the art comp page and index changes until sometime between Sunday, Feb 18 evening and Monday, Feb 19, by 8:00 am.   I will be out of cell service (in the Mojave Dessert) during the time it needs to be merged.  Please make sure the changes I intended are functional.  I will be back in Pullman by Feb 22-23.

Changes to the index:
Adding a pic for presidents day launch, new all text, and excerpt.
League Art Competition - Red Button year update and should bring people to the new art comp page/post...
https://lwvpullman.org/docs/art%20competition/civics%20education/Visual_Arts_Competition/

Art Comp post changes:
Added theme banner pic and theme wording.
Art Competition Flyers and Entry Form (one to print and an online entry form) and posters should all be clickable.
The program supplement should be clickable.  I am waiting on the Power point URL.  One of you might have to add that - there is a place for it just above the supplement.
